### PR TITLE
add support for sendCommand packet

### DIFF
--- a/src/structures/channel.ts
+++ b/src/structures/channel.ts
@@ -154,6 +154,16 @@ export class Channel extends Base {
 		return ret.ts as string;
 	}
 
+	public async sendCommand(command: string, parameters?: string): Promise<string> {
+		const send: any = { // tslint:disable-line no-any
+			command: command,
+			text: parameters,
+			channel: this.id,
+		};
+		const ret = await this.client.web(this.team.id).apiCall("chat.command", send);
+		return ret.ts as string;
+	}
+
 	public async sendMeMessage(sendable: SendableType): Promise<string> {
 		const send = this.resolveSendable(sendable);
 		if (this.isBotToken()) {


### PR DESCRIPTION
PR adds support for undocumented command that allows users to send slash commands to the channel: https://github.com/ErikKalkoken/slackApiDoc/blob/master/chat.command.md