### PR TITLE
Ignore team_rename RTM event

### DIFF
--- a/src/structures/client.ts
+++ b/src/structures/client.ts
@@ -349,10 +349,12 @@ export class Client extends EventEmitter {
 
 				rtm.on("team_rename", (data) => {
 					log.debug("RTM event: team_rename");
-					this.addTeam({
-						id: teamId,
-						name: data.name,
-					});
+					if (this.teams.size <= 1) {
+						this.addTeam({
+							id: teamId,
+							name: data.name,
+						});
+					}
 				});
 
 				rtm.on("member_joined_channel", (data) => {


### PR DESCRIPTION
These events get fired for shared teams too and it's impossible to
identify which team renamed.
Only way to refresh a team name is using the events api or restart
bridge.

From Slack docs:

Clients can use this to update the display of the workspace name as
soon as it changes. If they don't the client will receive the new name
the next time it calls rtm.start.